### PR TITLE
break up Env & Bottle

### DIFF
--- a/src/Bot.elm
+++ b/src/Bot.elm
@@ -37,11 +37,11 @@ placingPill bottle { orientation, coords } =
     let
         ( color_a, color_b ) =
             case orientation of
-                Vertical a b ->
-                    ( a, b )
+                Vertical pair ->
+                    pair
 
-                Horizontal a b ->
-                    ( a, b )
+                Horizontal pair ->
+                    pair
 
         options : List ( Int, Orientation )
         options =
@@ -84,7 +84,7 @@ placingPill bottle { orientation, coords } =
             (List.range minX maxX
                 |> List.map
                     (\x ->
-                        ( x, Vertical color_a color_b )
+                        ( x, Vertical ( color_a, color_b ) )
                     )
             )
                 ++ (if color_a == color_b then
@@ -92,10 +92,10 @@ placingPill bottle { orientation, coords } =
 
                     else
                         List.range minX (maxX - 1)
-                            |> List.map (\x -> ( x, Horizontal color_b color_a ))
+                            |> List.map (\x -> ( x, Horizontal ( color_b, color_a ) ))
                    )
                 ++ (List.range minX (maxX - 1)
-                        |> List.map (\x -> ( x, Horizontal color_a color_b ))
+                        |> List.map (\x -> ( x, Horizontal ( color_a, color_b ) ))
                    )
 
         peaks : List (Grid.Cell Contents)
@@ -151,10 +151,10 @@ placingPill bottle { orientation, coords } =
 
             else
                 case orientation of
-                    Horizontal _ _ ->
+                    Horizontal _ ->
                         0
 
-                    Vertical a b ->
+                    Vertical ( a, b ) ->
                         if a == b then
                             1
 
@@ -167,10 +167,10 @@ placingPill bottle { orientation, coords } =
                 (\( x, orientation_ ) ->
                     orientationBonus orientation_
                         + (case orientation_ of
-                            Horizontal a b ->
+                            Horizontal ( a, b ) ->
                                 colorIndexScore a x + colorIndexScore b (x + 1)
 
-                            Vertical a b ->
+                            Vertical ( a, b ) ->
                                 if a == b then
                                     colorIndexScore a x + colorIndexScore b x
 

--- a/src/Bot.elm
+++ b/src/Bot.elm
@@ -13,12 +13,8 @@ type alias Decision =
     ( Maybe Direction, Maybe ( Int, Orientation ) )
 
 
-
--- TODO: Env -> Decision
-
-
-trashBot : Bottle -> Mode -> Decision
-trashBot bottle mode =
+trashBot : Env.Model -> Decision
+trashBot { bottle, mode } =
     case mode of
         Falling _ ->
             ( Nothing, Nothing )

--- a/src/Bot.elm
+++ b/src/Bot.elm
@@ -4,15 +4,13 @@ import Array
 import Bottle
     exposing
         ( Bottle
-        , Color(..)
         , Contents
         , Direction(..)
         , Mode(..)
-        , Orientation(..)
-        , Pill
         )
 import Grid exposing (Cell, Coords)
 import List.Extra
+import Pill exposing (Color(..), Orientation(..), Pill)
 
 
 type alias Decision =

--- a/src/Bot.elm
+++ b/src/Bot.elm
@@ -1,20 +1,20 @@
 module Bot exposing (trashBot)
 
 import Array
-import Bottle
-    exposing
-        ( Bottle
-        , Contents
-        , Direction(..)
-        , Mode(..)
-        )
-import Grid exposing (Cell, Coords)
+import Bottle exposing (Bottle, Contents)
+import Direction exposing (Direction(..))
+import Env exposing (Mode(..))
+import Grid exposing (Cell)
 import List.Extra
 import Pill exposing (Color(..), Orientation(..), Pill)
 
 
 type alias Decision =
     ( Maybe Direction, Maybe ( Int, Orientation ) )
+
+
+
+-- TODO: Env -> Decision
 
 
 trashBot : Bottle -> Mode -> Decision

--- a/src/Bottle.elm
+++ b/src/Bottle.elm
@@ -1,66 +1,22 @@
-module Bottle exposing
-    ( Bottle
-    , Contents
-    , Direction(..)
-    , Mode(..)
-    , Model
-    , Msg(..)
-    , generateEmptyCoords
-    , generatePill
-    , getColor
-    , hasConflict
-    , init
-    , isCleared
-    , subscriptions
-    , totalViruses
-    , update
-    , view
-    , viewPill
-    , withBombs
-    , withBot
-    , withControls
-    , withNext
-    , withVirus
-    )
+module Bottle exposing (..)
 
-import Browser.Events exposing (onKeyDown)
-import Element exposing (none, px)
+import Direction exposing (Direction(..))
 import Grid exposing (Cell, Grid)
-import Html exposing (Html, div, text)
-import Html.Attributes exposing (style)
-import Html.Events exposing (keyCode)
-import Json.Decode as Decode
 import Pill exposing (Color(..), Orientation(..), Pill)
 import Random exposing (Generator(..))
 import RandomExtra exposing (selectWithDefault)
-import Set
 import Speed exposing (Speed(..))
-import Time exposing (Posix)
 
 
-
--- split Bottle (just a data structure?) from like Environment
--- bot goes Env -> Decision
--- things get more readable?
--- should only be a `goal` when Bot is in control
+type alias Bottle =
+    Grid Contents
 
 
-type Controls
-    = Keyboard (Int -> Maybe Direction)
-    | Bot BotInterface
+type alias Contents =
+    ( Color, CellType )
 
 
-type alias BotInterface =
-    Bottle -> Mode -> ( Maybe Direction, Maybe ( Int, Orientation ) )
-
-
-type Mode
-    = PlacingPill Pill
-    | Falling (List Color)
-    | Bombing
-
-
-type Type
+type CellType
     = Virus
       -- TODO: rename to `Pill` once files are broken up?
     | PillType (Maybe Dependent)
@@ -70,435 +26,19 @@ type alias Dependent =
     Direction
 
 
-getColor : Int -> Color
-getColor index =
-    case remainderBy 3 index of
-        0 ->
-            Red
+totalViruses : Bottle -> Int
+totalViruses bottle =
+    List.length <|
+        Grid.filter
+            (\c ->
+                case c.state of
+                    Just ( _, Virus ) ->
+                        True
 
-        1 ->
-            Blue
-
-        _ ->
-            Yellow
-
-
-type alias Contents =
-    ( Color, Type )
-
-
-type alias Bottle =
-    Grid Contents
-
-
-type alias Model =
-    { contents : Bottle
-    , mode : Mode
-    , next : ( Color, Color )
-    , controls : Controls
-    , bombs : List Color
-    , goal : Maybe ( Int, Orientation )
-    }
-
-
-init : Model
-init =
-    { contents = Grid.fromDimensions 8 16
-    , mode = Falling []
-    , next = ( Red, Red )
-    , controls = Keyboard (\_ -> Nothing)
-    , bombs = []
-    , goal = Nothing
-    }
-
-
-withNext : ( Color, Color ) -> Model -> Model
-withNext next model =
-    { model | next = next }
-
-
-withVirus : Color -> Grid.Coords -> Model -> Model
-withVirus color coords model =
-    { model
-        | contents =
-            Grid.setState ( color, Virus )
-                coords
-                model.contents
-    }
-
-
-withControls : (Int -> Maybe Direction) -> Model -> Model
-withControls controls model =
-    { model | controls = Keyboard controls }
-
-
-withBot : BotInterface -> Model -> Model
-withBot bot model =
-    { model | controls = Bot bot }
-
-
-withBombs : List Color -> Model -> Model
-withBombs colors model =
-    { model | bombs = model.bombs ++ colors }
-
-
-type
-    Msg
-    -- TODO: Pill?
-    = NewPill ( Color, Color )
-    | KeyDown (Maybe Direction)
-    | TickTock Posix
-    | Bomb Color Int
-    | SetGoal ( Maybe Direction, Maybe ( Int, Orientation ) )
-
-
-type Direction
-    = Up
-    | Down
-    | Left
-    | Right
-
-
-subscriptions : Speed -> Model -> Sub Msg
-subscriptions speed model =
-    Sub.batch
-        [ Time.every (Speed.tick speed) TickTock
-        , case model.controls of
-            Keyboard controls ->
-                onKeyDown (Decode.map (controls >> KeyDown) keyCode)
-
-            Bot bot ->
-                let
-                    direction =
-                        bot model.contents model.mode
-                in
-                Time.every (Speed.tick speed / 4) (\_ -> SetGoal direction)
-        ]
-
-
-
--- UPDATE
-
-
-update : { onBomb : List Color -> Maybe msg } -> Msg -> Model -> ( Model, Cmd Msg, Maybe msg )
-update props msg model =
-    case ( model.mode, msg ) of
-        ( Falling cleared, NewPill next ) ->
-            ( { model
-                | mode = PlacingPill (Pill.fromColors model.next)
-                , next = next
-              }
-            , Cmd.none
-            , if List.length cleared > 1 then
-                props.onBomb cleared
-
-              else
-                Nothing
-            )
-
-        ( PlacingPill pill, KeyDown key ) ->
-            let
-                moveIfAvailable : Pill -> ( Model, Cmd Msg, Maybe msg )
-                moveIfAvailable pill_ =
-                    withNothing
-                        (if isAvailable pill_ model.contents then
-                            { model | mode = PlacingPill pill_ }
-
-                         else
-                            model
-                        )
-            in
-            case key of
-                Just Up ->
-                    moveIfAvailable (Pill.turnRight pill)
-
-                Just direction ->
-                    moveIfAvailable
-                        (Pill.mapCoords (coordsWithDirection direction) pill)
-
-                Nothing ->
-                    withNothing model
-
-        ( _, KeyDown _ ) ->
-            withNothing model
-
-        ( _, SetGoal ( key, goal ) ) ->
-            update props (KeyDown key) { model | goal = goal }
-
-        ( _, TickTock _ ) ->
-            advance model
-
-        ( Bombing, Bomb color x ) ->
-            let
-                contents =
-                    Grid.setState
-                        ( color, PillType Nothing )
-                        ( x, 1 )
-                        model.contents
-
-                model_ =
-                    { model | contents = contents }
-            in
-            case model.bombs of
-                head :: tail ->
-                    ( { model_ | bombs = tail }
-                    , Random.generate (Bomb head) <|
-                        generateBomb model_.contents
-                    , Nothing
-                    )
-
-                _ ->
-                    ( { model_ | mode = Falling [] }, Cmd.none, Nothing )
-
-        _ ->
-            withNothing model
-
-
-withNothing : Model -> ( Model, Cmd Msg, Maybe msg )
-withNothing model =
-    ( model, Cmd.none, Nothing )
-
-
-advance : Model -> ( Model, Cmd Msg, Maybe msg )
-advance model =
-    case model.mode of
-        PlacingPill pill ->
-            let
-                newPill =
-                    Pill.mapCoords (coordsWithDirection Down) pill
-
-                afterPill : Pill -> Model
-                afterPill pill_ =
-                    let
-                        newContents =
-                            addPill pill_ model.contents
-
-                        modify =
-                            if canSweep newContents then
-                                sweep
-
-                            else
-                                \m -> { m | contents = fall newContents }
-                    in
-                    modify
-                        { model
-                            | mode = Falling []
-                            , contents = newContents
-                        }
-            in
-            withNothing
-                (if isAvailable newPill model.contents then
-                    { model | mode = PlacingPill newPill }
-
-                 else
-                    afterPill pill
-                )
-
-        Falling _ ->
-            let
-                timeToFall : Bool
-                timeToFall =
-                    model.contents
-                        |> Grid.filter
-                            (\{ coords } -> canFall coords model.contents)
-                        |> (List.isEmpty >> not)
-            in
-            if timeToFall then
-                withNothing { model | contents = fall model.contents }
-
-            else if canSweep model.contents then
-                ( sweep model, Cmd.none, Nothing )
-
-            else
-                case List.head model.bombs of
-                    Just _ ->
-                        advance { model | mode = Bombing }
-
-                    Nothing ->
-                        ( model
-                        , Random.generate NewPill <|
-                            generatePill
-                        , Nothing
-                        )
-
-        Bombing ->
-            case model.bombs of
-                head :: tail ->
-                    ( { model | bombs = tail }
-                    , Random.generate (Bomb head) <|
-                        generateBomb model.contents
-                    , Nothing
-                    )
-
-                _ ->
-                    ( model, Cmd.none, Nothing )
-
-
-addPill : Pill -> Bottle -> Bottle
-addPill pill bottle =
-    colorCoords pill
-        |> List.foldl
-            (\( coords_, color, dependent ) grid ->
-                Grid.setState ( color, PillType (Just dependent) ) coords_ grid
+                    _ ->
+                        False
             )
             bottle
-
-
-colorCoords : Pill -> List ( Grid.Coords, Color, Dependent )
-colorCoords pill =
-    let
-        ( ( a_color, a_dep ), ( b_color, b_dep ) ) =
-            case pill.orientation of
-                Horizontal ( a, b ) ->
-                    ( ( a, Right ), ( b, Left ) )
-
-                Vertical ( a, b ) ->
-                    ( ( a, Down ), ( b, Up ) )
-    in
-    case Pill.coordsPair pill of
-        first :: second :: [] ->
-            [ ( first, a_color, a_dep ), ( second, b_color, b_dep ) ]
-
-        _ ->
-            []
-
-
-fall : Bottle -> Bottle
-fall bottle =
-    Grid.map
-        (\({ coords, state } as cell) ->
-            let
-                above =
-                    coordsWithDirection Up coords
-            in
-            if canFall coords bottle then
-                -- look above
-                if canFall above bottle then
-                    { cell | state = .state <| Grid.findCellAtCoords above bottle }
-
-                else
-                    { cell | state = Nothing }
-
-            else if state == Nothing && canFall above bottle then
-                { cell | state = .state <| Grid.findCellAtCoords above bottle }
-
-            else
-                cell
-        )
-        bottle
-
-
-sweep : Model -> Model
-sweep ({ contents } as model) =
-    let
-        coordsLosingDependent =
-            contents
-                |> Grid.filterMap
-                    (\{ coords, state } ->
-                        case state of
-                            Just ( _, PillType (Just dependent) ) ->
-                                if isCleared coords contents then
-                                    Just <|
-                                        coordsWithDirection dependent coords
-
-                                else
-                                    Nothing
-
-                            _ ->
-                                Nothing
-                    )
-                |> Set.fromList
-
-        swept =
-            Grid.map
-                (\({ coords, state } as cell) ->
-                    if isCleared coords contents then
-                        { cell | state = Nothing }
-
-                    else if Set.member coords coordsLosingDependent then
-                        case state of
-                            Just ( color, _ ) ->
-                                { cell | state = Just ( color, PillType Nothing ) }
-
-                            Nothing ->
-                                cell
-
-                    else
-                        cell
-                )
-                contents
-
-        diff : List (Cell Contents)
-        diff =
-            Grid.difference
-                (\a b ->
-                    case ( a, b ) of
-                        ( Just _, Nothing ) ->
-                            True
-
-                        _ ->
-                            False
-                )
-                contents
-                swept
-
-        clearedLines : List (Cell Contents) -> List Color
-        clearedLines cells =
-            case cells of
-                [] ->
-                    []
-
-                x :: xs ->
-                    case x.state of
-                        Just ( color, _ ) ->
-                            color
-                                :: (xs
-                                        |> List.filter
-                                            (\c ->
-                                                case ( x.coords, c.coords ) of
-                                                    ( ( xx, xy ), ( cx, cy ) ) ->
-                                                        cx /= xx && cy /= xy
-                                            )
-                                        |> clearedLines
-                                   )
-
-                        Nothing ->
-                            []
-
-        alreadyCleared =
-            case model.mode of
-                Falling cleared ->
-                    cleared
-
-                _ ->
-                    -- should always be in Falling. can types enforce this?
-                    []
-    in
-    { model | contents = swept, mode = Falling (alreadyCleared ++ clearedLines diff) }
-
-
-
--- TODO: reverse arg order
-
-
-coordsWithDirection : Direction -> Grid.Coords -> Grid.Coords
-coordsWithDirection direction ( x, y ) =
-    case direction of
-        Up ->
-            ( x, y - 1 )
-
-        Down ->
-            ( x, y + 1 )
-
-        Left ->
-            ( x - 1, y )
-
-        Right ->
-            ( x + 1, y )
-
-
-
--- QUERIES
 
 
 isAvailable : Pill -> Bottle -> Bool
@@ -529,16 +69,6 @@ isAvailable pill grid =
                 |> List.all identity
     in
     inBottle && noOccupant
-
-
-canSweep : Bottle -> Bool
-canSweep grid =
-    grid
-        |> Grid.filter
-            (\cell ->
-                isCleared cell.coords grid
-            )
-        |> (List.length >> (/=) 0)
 
 
 canFall : Grid.Coords -> Bottle -> Bool
@@ -589,6 +119,16 @@ canFall coords bottle =
             False
 
 
+canSweep : Bottle -> Bool
+canSweep grid =
+    grid
+        |> Grid.filter
+            (\cell ->
+                isCleared cell.coords grid
+            )
+        |> (List.length >> (/=) 0)
+
+
 isCleared : Grid.Coords -> Bottle -> Bool
 isCleared ( x, y ) grid =
     let
@@ -631,31 +171,58 @@ isCleared ( x, y ) grid =
                 (vertical ++ horizontal)
 
 
-totalViruses : Bottle -> Int
-totalViruses contents =
-    List.length <|
-        Grid.filter
-            (\c ->
-                case c.state of
-                    Just ( _, Virus ) ->
-                        True
-
-                    _ ->
-                        False
+addPill : Pill -> Bottle -> Bottle
+addPill pill bottle =
+    colorCoords pill
+        |> List.foldl
+            (\( coords_, color, dependent ) grid ->
+                Grid.setState ( color, PillType (Just dependent) ) coords_ grid
             )
-            contents
+            bottle
 
 
-hasConflict : Model -> Bool
-hasConflict { mode, contents } =
-    case mode of
-        PlacingPill pill ->
-            Pill.coordsPair pill
-                |> List.map (\p -> Grid.isEmpty p contents)
-                |> List.any not
+fall : Bottle -> Bottle
+fall bottle =
+    Grid.map
+        (\({ coords, state } as cell) ->
+            let
+                above =
+                    coordsWithDirection Up coords
+            in
+            if canFall coords bottle then
+                -- look above
+                if canFall above bottle then
+                    { cell | state = .state <| Grid.findCellAtCoords above bottle }
+
+                else
+                    { cell | state = Nothing }
+
+            else if state == Nothing && canFall above bottle then
+                { cell | state = .state <| Grid.findCellAtCoords above bottle }
+
+            else
+                cell
+        )
+        bottle
+
+
+colorCoords : Pill -> List ( Grid.Coords, Color, Dependent )
+colorCoords pill =
+    let
+        ( ( a_color, a_dep ), ( b_color, b_dep ) ) =
+            case pill.orientation of
+                Horizontal ( a, b ) ->
+                    ( ( a, Right ), ( b, Left ) )
+
+                Vertical ( a, b ) ->
+                    ( ( a, Down ), ( b, Up ) )
+    in
+    case Pill.coordsPair pill of
+        first :: second :: [] ->
+            [ ( first, a_color, a_dep ), ( second, b_color, b_dep ) ]
 
         _ ->
-            False
+            []
 
 
 
@@ -705,123 +272,6 @@ generateBomb bottle =
 
 
 
--- VIEW
-
-
-view : Model -> Html msg
-view { contents, mode, goal } =
-    div []
-        [ div
-            [ style "display" "inline-block"
-            , style "border" "3px solid #CCC"
-            , style "border-radius" "3px"
-            , style "background" "#000"
-            ]
-            (List.map
-                (\column ->
-                    div
-                        [ style "display" "inline-block", style "vertical-align" "top" ]
-                        (List.map
-                            (\cell ->
-                                case cell.state of
-                                    Nothing ->
-                                        div cellStyle []
-
-                                    Just ( color, PillType dependent ) ->
-                                        viewPillCell dependent color
-
-                                    Just ( color, Virus ) ->
-                                        viewVirus color
-                            )
-                            column
-                        )
-                )
-                (case mode of
-                    PlacingPill pill ->
-                        addPill pill contents
-
-                    _ ->
-                        contents
-                )
-            )
-        ]
-
-
-viewPillCell : Maybe Dependent -> Color -> Html msg
-viewPillCell dependent color =
-    viewColor color
-        8
-        (case dependent of
-            Just Up ->
-                [ style "border-top-left-radius" (px 0), style "border-top-right-radius" (px 0) ]
-
-            Just Down ->
-                [ style "border-bottom-left-radius" (px 0), style "border-bottom-right-radius" (px 0) ]
-
-            Just Left ->
-                [ style "border-top-left-radius" (px 0), style "border-bottom-left-radius" (px 0) ]
-
-            Just Right ->
-                [ style "border-top-right-radius" (px 0), style "border-bottom-right-radius" (px 0) ]
-
-            Nothing ->
-                []
-        )
-        []
-
-
-viewPill : ( Color, Color ) -> List (Html msg)
-viewPill ( left, right ) =
-    [ viewPillCell (Just Right) left
-    , viewPillCell (Just Left) right
-    ]
-
-
-viewVirus : Color -> Html msg
-viewVirus color =
-    viewColor color 3 [] [ text "◔̯◔" ]
-
-
-viewColor : Color -> Int -> List (Html.Attribute msg) -> List (Html msg) -> Html msg
-viewColor color radius extraStyle =
-    let
-        bg =
-            case color of
-                Red ->
-                    "#e8005a"
-
-                Blue ->
-                    "#39bdff"
-
-                Yellow ->
-                    "#ffbd03"
-    in
-    div
-        ([ style "background-color" bg
-         , style "border-top-left-radius" (px radius)
-         , style "border-top-right-radius" (px radius)
-         , style "border-bottom-left-radius" (px radius)
-         , style "border-bottom-right-radius" (px radius)
-         ]
-            ++ cellStyle
-            ++ extraStyle
-        )
-
-
-cellStyle : List (Html.Attribute msg)
-cellStyle =
-    [ style "width" (px cellSize)
-    , style "height" (px cellSize)
-    , style "border" "1px solid black"
-    ]
-
-
-cellSize : Int
-cellSize =
-    24
-
-
-
 -- UTILS
 
 
@@ -832,3 +282,32 @@ subLists len list =
 
     else
         List.take len list :: subLists len (List.drop 1 list)
+
+
+coordsWithDirection : Direction -> Grid.Coords -> Grid.Coords
+coordsWithDirection direction ( x, y ) =
+    case direction of
+        Up ->
+            ( x, y - 1 )
+
+        Down ->
+            ( x, y + 1 )
+
+        Left ->
+            ( x - 1, y )
+
+        Right ->
+            ( x + 1, y )
+
+
+getColor : Int -> Color
+getColor index =
+    case remainderBy 3 index of
+        0 ->
+            Red
+
+        1 ->
+            Blue
+
+        _ ->
+            Yellow

--- a/src/Bottle.elm
+++ b/src/Bottle.elm
@@ -185,11 +185,7 @@ update props msg model =
     case ( model.mode, msg ) of
         ( Falling cleared, NewPill next ) ->
             ( { model
-                | mode =
-                    PlacingPill
-                        { orientation = Horizontal model.next
-                        , coords = ( 4, 0 )
-                        }
+                | mode = PlacingPill (Pill.fromColors model.next)
                 , next = next
               }
             , Cmd.none

--- a/src/Bottle.elm
+++ b/src/Bottle.elm
@@ -69,8 +69,8 @@ type alias Pill =
 
 
 type Orientation
-    = Horizontal Color Color
-    | Vertical Color Color
+    = Horizontal ( Color, Color )
+    | Vertical ( Color, Color )
 
 
 type Type
@@ -201,14 +201,10 @@ update : { onBomb : List Color -> Maybe msg } -> Msg -> Model -> ( Model, Cmd Ms
 update props msg model =
     case ( model.mode, msg ) of
         ( Falling cleared, NewPill next ) ->
-            let
-                ( a, b ) =
-                    model.next
-            in
             ( { model
                 | mode =
                     PlacingPill
-                        { orientation = Horizontal a b
+                        { orientation = Horizontal model.next
                         , coords = ( 4, 0 )
                         }
                 , next = next
@@ -240,11 +236,11 @@ update props msg model =
                             (\o ->
                                 -- TODO: Pill.flip?
                                 case o of
-                                    Horizontal a b ->
-                                        Vertical a b
+                                    Horizontal pair ->
+                                        Vertical pair
 
-                                    Vertical a b ->
-                                        Horizontal b a
+                                    Vertical ( a, b ) ->
+                                        Horizontal ( b, a )
                             )
                             pill
                         )
@@ -396,10 +392,10 @@ colorCoords pill =
     let
         ( ( a_color, a_dep ), ( b_color, b_dep ) ) =
             case pill.orientation of
-                Horizontal a b ->
+                Horizontal ( a, b ) ->
                     ( ( a, Right ), ( b, Left ) )
 
-                Vertical a b ->
+                Vertical ( a, b ) ->
                     ( ( a, Down ), ( b, Up ) )
     in
     case pillCoordsPair pill of
@@ -555,10 +551,10 @@ pillCoordsPair pill =
             pill.coords
     in
     case pill.orientation of
-        Horizontal _ _ ->
+        Horizontal _ ->
             [ ( x, y + 1 ), ( x + 1, y + 1 ) ]
 
-        Vertical _ _ ->
+        Vertical _ ->
             [ ( x, y ), ( x, y + 1 ) ]
 
 
@@ -573,10 +569,10 @@ isAvailable pill grid =
 
         withinRight =
             case pill.orientation of
-                Vertical _ _ ->
+                Vertical _ ->
                     x <= Grid.width grid
 
-                Horizontal _ _ ->
+                Horizontal _ ->
                     x < Grid.width grid
 
         inBottle =

--- a/src/BottleCreator.elm
+++ b/src/BottleCreator.elm
@@ -5,8 +5,9 @@ module BottleCreator exposing
     , update
     )
 
-import Bottle exposing (Bottle, Color(..))
+import Bottle exposing (Bottle)
 import Grid
+import Pill exposing (Color(..))
 import Random exposing (Generator(..))
 
 

--- a/src/Controls.elm
+++ b/src/Controls.elm
@@ -1,6 +1,6 @@
 module Controls exposing (arrows, wasd)
 
-import Bottle exposing (Direction(..))
+import Direction exposing (Direction(..))
 
 
 arrows : Int -> Maybe Direction

--- a/src/Direction.elm
+++ b/src/Direction.elm
@@ -1,0 +1,8 @@
+module Direction exposing (Direction(..))
+
+
+type Direction
+    = Up
+    | Down
+    | Left
+    | Right

--- a/src/Env.elm
+++ b/src/Env.elm
@@ -218,20 +218,20 @@ advance model =
                 afterPill : Pill -> Model
                 afterPill pill_ =
                     let
-                        newContents =
+                        newBottle =
                             Bottle.addPill pill_ model.bottle
 
                         modify =
-                            if Bottle.canSweep newContents then
+                            if Bottle.canSweep newBottle then
                                 sweep
 
                             else
-                                \m -> { m | bottle = Bottle.fall newContents }
+                                \m -> { m | bottle = Bottle.fall newBottle }
                     in
                     modify
                         { model
                             | mode = Falling []
-                            , bottle = newContents
+                            , bottle = newBottle
                         }
             in
             withNothing

--- a/src/Env.elm
+++ b/src/Env.elm
@@ -32,11 +32,6 @@ import Speed exposing (Speed(..))
 import Time exposing (Posix)
 
 
-
--- things get more readable?
--- should only be a `goal` when Bot is in control
-
-
 type Controls
     = Keyboard (Int -> Maybe Direction)
     | Bot BotInterface

--- a/src/Env.elm
+++ b/src/Env.elm
@@ -1,0 +1,511 @@
+module Env exposing
+    ( Mode(..)
+    , Model
+    , Msg(..)
+    , hasConflict
+    , init
+    , subscriptions
+    , totalViruses
+    , update
+    , view
+    , viewPill
+    , withBombs
+    , withBot
+    , withControls
+    , withNext
+    , withVirus
+    )
+
+import Bottle exposing (Bottle, CellType(..))
+import Browser.Events exposing (onKeyDown)
+import Direction exposing (Direction(..))
+import Element exposing (none, px)
+import Grid exposing (Cell)
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (style)
+import Html.Events exposing (keyCode)
+import Json.Decode as Decode
+import Pill exposing (Color(..), Orientation(..), Pill)
+import Random exposing (Generator(..))
+import Set
+import Speed exposing (Speed(..))
+import Time exposing (Posix)
+
+
+
+-- things get more readable?
+-- should only be a `goal` when Bot is in control
+
+
+type Controls
+    = Keyboard (Int -> Maybe Direction)
+    | Bot BotInterface
+
+
+type alias BotInterface =
+    Bottle -> Mode -> ( Maybe Direction, Maybe ( Int, Orientation ) )
+
+
+type Mode
+    = PlacingPill Pill
+    | Falling (List Color)
+    | Bombing
+
+
+type alias Model =
+    { bottle : Bottle
+    , mode : Mode
+    , next : ( Color, Color )
+    , controls : Controls
+    , bombs : List Color
+    , goal : Maybe ( Int, Orientation )
+    }
+
+
+init : Model
+init =
+    { bottle = Grid.fromDimensions 8 16
+    , mode = Falling []
+    , next = ( Red, Red )
+    , controls = Keyboard (\_ -> Nothing)
+    , bombs = []
+    , goal = Nothing
+    }
+
+
+withNext : ( Color, Color ) -> Model -> Model
+withNext next model =
+    { model | next = next }
+
+
+withVirus : Color -> Grid.Coords -> Model -> Model
+withVirus color coords model =
+    { model
+        | bottle =
+            Grid.setState ( color, Virus )
+                coords
+                model.bottle
+    }
+
+
+withControls : (Int -> Maybe Direction) -> Model -> Model
+withControls controls model =
+    { model | controls = Keyboard controls }
+
+
+withBot : BotInterface -> Model -> Model
+withBot bot model =
+    { model | controls = Bot bot }
+
+
+withBombs : List Color -> Model -> Model
+withBombs colors model =
+    { model | bombs = model.bombs ++ colors }
+
+
+type Msg
+    = NewPill ( Color, Color ) -- TODO: Pill?
+    | KeyDown (Maybe Direction)
+    | TickTock Posix
+    | Bomb Color Int
+    | SetGoal ( Maybe Direction, Maybe ( Int, Orientation ) )
+
+
+subscriptions : Speed -> Model -> Sub Msg
+subscriptions speed model =
+    Sub.batch
+        [ Time.every (Speed.tick speed) TickTock
+        , case model.controls of
+            Keyboard controls ->
+                onKeyDown (Decode.map (controls >> KeyDown) keyCode)
+
+            Bot bot ->
+                let
+                    direction =
+                        bot model.bottle model.mode
+                in
+                Time.every (Speed.tick speed / 4) (\_ -> SetGoal direction)
+        ]
+
+
+
+-- UPDATE
+
+
+update : { onBomb : List Color -> Maybe msg } -> Msg -> Model -> ( Model, Cmd Msg, Maybe msg )
+update props msg model =
+    case ( model.mode, msg ) of
+        ( Falling cleared, NewPill next ) ->
+            ( { model
+                | mode = PlacingPill (Pill.fromColors model.next)
+                , next = next
+              }
+            , Cmd.none
+            , if List.length cleared > 1 then
+                props.onBomb cleared
+
+              else
+                Nothing
+            )
+
+        ( PlacingPill pill, KeyDown key ) ->
+            let
+                moveIfAvailable : Pill -> ( Model, Cmd Msg, Maybe msg )
+                moveIfAvailable pill_ =
+                    withNothing
+                        (if Bottle.isAvailable pill_ model.bottle then
+                            { model | mode = PlacingPill pill_ }
+
+                         else
+                            model
+                        )
+            in
+            case key of
+                Just Up ->
+                    moveIfAvailable (Pill.turnRight pill)
+
+                Just direction ->
+                    moveIfAvailable
+                        (Pill.mapCoords (Bottle.coordsWithDirection direction) pill)
+
+                Nothing ->
+                    withNothing model
+
+        ( _, KeyDown _ ) ->
+            withNothing model
+
+        ( _, SetGoal ( key, goal ) ) ->
+            update props (KeyDown key) { model | goal = goal }
+
+        ( _, TickTock _ ) ->
+            advance model
+
+        ( Bombing, Bomb color x ) ->
+            let
+                bottle =
+                    Grid.setState
+                        ( color, PillType Nothing )
+                        ( x, 1 )
+                        model.bottle
+
+                model_ =
+                    { model | bottle = bottle }
+            in
+            case model.bombs of
+                head :: tail ->
+                    ( { model_ | bombs = tail }
+                    , Random.generate (Bomb head) <|
+                        Bottle.generateBomb model_.bottle
+                    , Nothing
+                    )
+
+                _ ->
+                    ( { model_ | mode = Falling [] }, Cmd.none, Nothing )
+
+        _ ->
+            withNothing model
+
+
+withNothing : Model -> ( Model, Cmd Msg, Maybe msg )
+withNothing model =
+    ( model, Cmd.none, Nothing )
+
+
+advance : Model -> ( Model, Cmd Msg, Maybe msg )
+advance model =
+    case model.mode of
+        PlacingPill pill ->
+            let
+                newPill =
+                    Pill.mapCoords (Bottle.coordsWithDirection Down) pill
+
+                afterPill : Pill -> Model
+                afterPill pill_ =
+                    let
+                        newContents =
+                            Bottle.addPill pill_ model.bottle
+
+                        modify =
+                            if Bottle.canSweep newContents then
+                                sweep
+
+                            else
+                                \m -> { m | bottle = Bottle.fall newContents }
+                    in
+                    modify
+                        { model
+                            | mode = Falling []
+                            , bottle = newContents
+                        }
+            in
+            withNothing
+                (if Bottle.isAvailable newPill model.bottle then
+                    { model | mode = PlacingPill newPill }
+
+                 else
+                    afterPill pill
+                )
+
+        Falling _ ->
+            let
+                timeToFall : Bool
+                timeToFall =
+                    model.bottle
+                        |> Grid.filter
+                            (\{ coords } -> Bottle.canFall coords model.bottle)
+                        |> (List.isEmpty >> not)
+            in
+            if timeToFall then
+                withNothing { model | bottle = Bottle.fall model.bottle }
+
+            else if Bottle.canSweep model.bottle then
+                ( sweep model, Cmd.none, Nothing )
+
+            else if List.length model.bombs == 0 then
+                ( model
+                , Random.generate NewPill <|
+                    Bottle.generatePill
+                , Nothing
+                )
+
+            else
+                advance { model | mode = Bombing }
+
+        Bombing ->
+            case model.bombs of
+                head :: tail ->
+                    ( { model | bombs = tail }
+                    , Random.generate (Bomb head) <|
+                        Bottle.generateBomb model.bottle
+                    , Nothing
+                    )
+
+                _ ->
+                    ( model, Cmd.none, Nothing )
+
+
+sweep : Model -> Model
+sweep ({ bottle } as model) =
+    let
+        coordsLosingDependent =
+            bottle
+                |> Grid.filterMap
+                    (\{ coords, state } ->
+                        case state of
+                            Just ( _, PillType (Just dependent) ) ->
+                                if Bottle.isCleared coords bottle then
+                                    Just <|
+                                        Bottle.coordsWithDirection dependent coords
+
+                                else
+                                    Nothing
+
+                            _ ->
+                                Nothing
+                    )
+                |> Set.fromList
+
+        swept =
+            Grid.map
+                (\({ coords, state } as cell) ->
+                    if Bottle.isCleared coords bottle then
+                        { cell | state = Nothing }
+
+                    else if Set.member coords coordsLosingDependent then
+                        case state of
+                            Just ( color, _ ) ->
+                                { cell | state = Just ( color, PillType Nothing ) }
+
+                            Nothing ->
+                                cell
+
+                    else
+                        cell
+                )
+                bottle
+
+        diff : List (Cell Bottle.Contents)
+        diff =
+            Grid.difference
+                (\a b ->
+                    case ( a, b ) of
+                        ( Just _, Nothing ) ->
+                            True
+
+                        _ ->
+                            False
+                )
+                bottle
+                swept
+
+        clearedLines : List (Cell Bottle.Contents) -> List Color
+        clearedLines cells =
+            case cells of
+                [] ->
+                    []
+
+                x :: xs ->
+                    case x.state of
+                        Just ( color, _ ) ->
+                            color
+                                :: (xs
+                                        |> List.filter
+                                            (\c ->
+                                                case ( x.coords, c.coords ) of
+                                                    ( ( xx, xy ), ( cx, cy ) ) ->
+                                                        cx /= xx && cy /= xy
+                                            )
+                                        |> clearedLines
+                                   )
+
+                        Nothing ->
+                            []
+
+        alreadyCleared =
+            case model.mode of
+                Falling cleared ->
+                    cleared
+
+                _ ->
+                    -- should always be in Falling. can types enforce this?
+                    []
+    in
+    { model | bottle = swept, mode = Falling (alreadyCleared ++ clearedLines diff) }
+
+
+
+-- QUERIES
+
+
+hasConflict : Model -> Bool
+hasConflict { mode, bottle } =
+    case mode of
+        PlacingPill pill ->
+            Pill.coordsPair pill
+                |> List.map (\coords -> Grid.isEmpty coords bottle)
+                |> List.any not
+
+        _ ->
+            False
+
+
+totalViruses : Model -> Int
+totalViruses { bottle } =
+    Bottle.totalViruses bottle
+
+
+
+-- VIEW
+
+
+view : Model -> Html msg
+view { bottle, mode, goal } =
+    div []
+        [ div
+            [ style "display" "inline-block"
+            , style "border" "3px solid #CCC"
+            , style "border-radius" "3px"
+            , style "background" "#000"
+            ]
+            (List.map
+                (\column ->
+                    div
+                        [ style "display" "inline-block", style "vertical-align" "top" ]
+                        (List.map
+                            (\cell ->
+                                case cell.state of
+                                    Nothing ->
+                                        div cellStyle []
+
+                                    Just ( color, PillType dependent ) ->
+                                        viewPillCell dependent color
+
+                                    Just ( color, Virus ) ->
+                                        viewVirus color
+                            )
+                            column
+                        )
+                )
+                (case mode of
+                    PlacingPill pill ->
+                        Bottle.addPill pill bottle
+
+                    _ ->
+                        bottle
+                )
+            )
+        ]
+
+
+viewPillCell : Maybe Direction -> Color -> Html msg
+viewPillCell dependent color =
+    viewColor color
+        8
+        (case dependent of
+            Just Up ->
+                [ style "border-top-left-radius" (px 0), style "border-top-right-radius" (px 0) ]
+
+            Just Down ->
+                [ style "border-bottom-left-radius" (px 0), style "border-bottom-right-radius" (px 0) ]
+
+            Just Left ->
+                [ style "border-top-left-radius" (px 0), style "border-bottom-left-radius" (px 0) ]
+
+            Just Right ->
+                [ style "border-top-right-radius" (px 0), style "border-bottom-right-radius" (px 0) ]
+
+            Nothing ->
+                []
+        )
+        []
+
+
+viewPill : ( Color, Color ) -> List (Html msg)
+viewPill ( left, right ) =
+    [ viewPillCell (Just Right) left
+    , viewPillCell (Just Left) right
+    ]
+
+
+viewVirus : Color -> Html msg
+viewVirus color =
+    viewColor color 3 [] [ text "◔̯◔" ]
+
+
+viewColor : Color -> Int -> List (Html.Attribute msg) -> List (Html msg) -> Html msg
+viewColor color radius extraStyle =
+    let
+        bg =
+            case color of
+                Red ->
+                    "#e8005a"
+
+                Blue ->
+                    "#39bdff"
+
+                Yellow ->
+                    "#ffbd03"
+    in
+    div
+        ([ style "background-color" bg
+         , style "border-top-left-radius" (px radius)
+         , style "border-top-right-radius" (px radius)
+         , style "border-bottom-left-radius" (px radius)
+         , style "border-bottom-right-radius" (px radius)
+         ]
+            ++ cellStyle
+            ++ extraStyle
+        )
+
+
+cellStyle : List (Html.Attribute msg)
+cellStyle =
+    [ style "width" (px cellSize)
+    , style "height" (px cellSize)
+    , style "border" "1px solid black"
+    ]
+
+
+cellSize : Int
+cellSize =
+    24

--- a/src/Env.elm
+++ b/src/Env.elm
@@ -43,7 +43,7 @@ type Controls
 
 
 type alias BotInterface =
-    Bottle -> Mode -> ( Maybe Direction, Maybe ( Int, Orientation ) )
+    Model -> ( Maybe Direction, Maybe ( Int, Orientation ) )
 
 
 type Mode
@@ -120,11 +120,7 @@ subscriptions speed model =
                 onKeyDown (Decode.map (controls >> KeyDown) keyCode)
 
             Bot bot ->
-                let
-                    direction =
-                        bot model.bottle model.mode
-                in
-                Time.every (Speed.tick speed / 4) (\_ -> SetGoal direction)
+                Time.every (Speed.tick speed / 4) (\_ -> SetGoal (bot model))
         ]
 
 

--- a/src/EnvCreator.elm
+++ b/src/EnvCreator.elm
@@ -1,4 +1,4 @@
-module BottleCreator exposing
+module EnvCreator exposing
     ( Model
     , Msg(..)
     , init
@@ -6,6 +6,7 @@ module BottleCreator exposing
     )
 
 import Bottle exposing (Bottle)
+import Env
 import Grid
 import Pill exposing (Color(..))
 import Random exposing (Generator(..))
@@ -13,7 +14,7 @@ import Random exposing (Generator(..))
 
 type alias Model =
     { level : Int
-    , bottle : Bottle.Model
+    , env : Env.Model
     }
 
 
@@ -25,13 +26,13 @@ type Msg
 init : Int -> ( Model, Cmd Msg )
 init level =
     let
-        bottle =
-            Bottle.init
+        env =
+            Env.init
     in
     ( { level = level
-      , bottle = bottle
+      , env = env
       }
-    , randomNewVirus bottle.contents
+    , randomNewVirus env.bottle
     )
 
 
@@ -41,30 +42,30 @@ virusesForLevel level =
 
 
 update : { onCreated : Model -> msg } -> Msg -> Model -> ( Model, Cmd Msg, Maybe msg )
-update { onCreated } action ({ level, bottle } as model) =
+update { onCreated } action ({ level, env } as model) =
     case action of
         NewVirus coords ->
             let
-                newBottle =
-                    Bottle.withVirus color coords bottle
+                newEnv =
+                    Env.withVirus color coords env
 
                 color =
-                    Bottle.getColor (Bottle.totalViruses bottle.contents)
+                    Bottle.getColor (Bottle.totalViruses env.bottle)
             in
-            if Bottle.isCleared coords newBottle.contents then
+            if Bottle.isCleared coords newEnv.bottle then
                 -- would create a 4-in-a-row, so let's try a new virus
-                ( model, randomNewVirus bottle.contents, Nothing )
+                ( model, randomNewVirus env.bottle, Nothing )
 
-            else if Bottle.totalViruses newBottle.contents >= virusesForLevel level then
-                ( { model | bottle = newBottle }
+            else if Bottle.totalViruses newEnv.bottle >= virusesForLevel level then
+                ( { model | env = newEnv }
                 , Random.generate NewPill <|
                     Bottle.generatePill
                 , Nothing
                 )
 
             else
-                ( { model | bottle = newBottle }
-                , randomNewVirus newBottle.contents
+                ( { model | env = newEnv }
+                , randomNewVirus newEnv.bottle
                 , Nothing
                 )
 
@@ -72,8 +73,8 @@ update { onCreated } action ({ level, bottle } as model) =
             let
                 model_ =
                     { level = level
-                    , bottle =
-                        bottle |> Bottle.withNext colors
+                    , env =
+                        env |> Env.withNext colors
                     }
             in
             ( model_
@@ -83,6 +84,6 @@ update { onCreated } action ({ level, bottle } as model) =
 
 
 randomNewVirus : Bottle -> Cmd Msg
-randomNewVirus bottle =
+randomNewVirus env =
     Random.generate NewVirus <|
-        Bottle.generateEmptyCoords bottle
+        Bottle.generateEmptyCoords env

--- a/src/OnePlayer/Game.elm
+++ b/src/OnePlayer/Game.elm
@@ -208,8 +208,8 @@ update { onLeave } action model =
 updatePlayState : msg -> Env.Msg -> State -> ( Model, Cmd Msg, Maybe msg )
 updatePlayState onLeave action ({ env, speed, score } as model) =
     let
-        withBottle : Env.Model -> Model
-        withBottle newEnv =
+        withEnv : Env.Model -> Model
+        withEnv newEnv =
             let
                 sweptViruses =
                     Env.totalViruses env - Env.totalViruses newEnv
@@ -225,7 +225,7 @@ updatePlayState onLeave action ({ env, speed, score } as model) =
     in
     Env.update { onBomb = \_ -> Nothing } action env
         |> Component.raiseOutMsg (update { onLeave = onLeave })
-            withBottle
+            withEnv
             EnvMsg
 
 

--- a/src/Pill.elm
+++ b/src/Pill.elm
@@ -1,0 +1,66 @@
+module Pill exposing
+    ( Color(..)
+    , Orientation(..)
+    , Pill
+    , coordsPair
+    , mapCoords
+    , mapOrientation
+    , turnRight
+    )
+
+import Grid
+
+
+type alias Pill =
+    { orientation : Orientation
+    , coords : Grid.Coords
+    }
+
+
+type Orientation
+    = Horizontal ( Color, Color )
+    | Vertical ( Color, Color )
+
+
+type Color
+    = Red
+    | Blue
+    | Yellow
+
+
+mapCoords : (Grid.Coords -> Grid.Coords) -> Pill -> Pill
+mapCoords map { orientation, coords } =
+    { orientation = orientation, coords = map coords }
+
+
+mapOrientation : (Orientation -> Orientation) -> Pill -> Pill
+mapOrientation map { orientation, coords } =
+    { orientation = map orientation, coords = coords }
+
+
+turnRight : Pill -> Pill
+turnRight pill =
+    mapOrientation
+        (\o ->
+            case o of
+                Horizontal pair ->
+                    Vertical pair
+
+                Vertical ( a, b ) ->
+                    Horizontal ( b, a )
+        )
+        pill
+
+
+coordsPair : Pill -> List Grid.Coords
+coordsPair pill =
+    let
+        ( x, y ) =
+            pill.coords
+    in
+    case pill.orientation of
+        Horizontal _ ->
+            [ ( x, y + 1 ), ( x + 1, y + 1 ) ]
+
+        Vertical _ ->
+            [ ( x, y ), ( x, y + 1 ) ]

--- a/src/Pill.elm
+++ b/src/Pill.elm
@@ -3,17 +3,25 @@ module Pill exposing
     , Orientation(..)
     , Pill
     , coordsPair
+    , fromColors
     , mapCoords
     , mapOrientation
     , turnRight
     )
 
-import Grid
+import Grid exposing (Coords)
 
 
 type alias Pill =
     { orientation : Orientation
-    , coords : Grid.Coords
+    , coords : Coords
+    }
+
+
+fromColors : ( Color, Color ) -> Pill
+fromColors colors =
+    { orientation = Horizontal colors
+    , coords = ( 4, 0 )
     }
 
 
@@ -28,7 +36,7 @@ type Color
     | Yellow
 
 
-mapCoords : (Grid.Coords -> Grid.Coords) -> Pill -> Pill
+mapCoords : (Coords -> Coords) -> Pill -> Pill
 mapCoords map { orientation, coords } =
     { orientation = orientation, coords = map coords }
 
@@ -52,7 +60,7 @@ turnRight pill =
         pill
 
 
-coordsPair : Pill -> List Grid.Coords
+coordsPair : Pill -> List Coords
 coordsPair pill =
     let
         ( x, y ) =

--- a/src/Speed.elm
+++ b/src/Speed.elm
@@ -1,4 +1,4 @@
-module Speed exposing (..)
+module Speed exposing (Speed(..), tick, toString)
 
 
 type Speed

--- a/src/TwoPlayer/Game.elm
+++ b/src/TwoPlayer/Game.elm
@@ -8,7 +8,7 @@ module TwoPlayer.Game exposing
     , view
     )
 
-import Bottle exposing (Color(..))
+import Bottle
 import Component
 import Element exposing (Element, none, styled)
 import Html exposing (Html, div, h3, p, span, text)
@@ -23,6 +23,7 @@ import MatchupCreator
         , mapBottle
         , mapPlayer
         )
+import Pill exposing (Color(..))
 import Speed exposing (Speed(..))
 
 


### PR DESCRIPTION
now, `Bottle` is a data structure that handles the mechanics and rules of the bottle itself. `Env` is the surrounding context, including the next pill, who's in control, and any queued bombs waiting to drop.

this leads to more readable, higher-level logic in `Env` and just generally better naming.

`Pill` also became an `Orientation` at a `Grid.Coords`. this pair usually traveled together, but now, it's contained in a record.